### PR TITLE
Implement FW CAT command

### DIFF
--- a/WhiteButtonsUSDX.ino
+++ b/WhiteButtonsUSDX.ino
@@ -5358,6 +5358,9 @@ void analyseCATcmd()    // Supported Kenwood TS-480 protocol CAT commands
 	else if ((CATcmd[0] == 'V') && (CATcmd[1] == 'X') && (CATcmd[2] != ';'))
 		Command_VX(CATcmd[2]);
 
+	else if ((CATcmd[0] == 'F') && (CATcmd[1] == 'W') && (CATcmd[2] == ';'))
+		Command_FW();
+
 	/*
 	The following CAT extensions are available to support remote operatons. Use a baudrate of 115200 when enabling CAT_STREAMING config switch:
 
@@ -5683,6 +5686,19 @@ void Command_PS()
 
 void Command_PS1()
 {
+}
+
+void Command_FW()
+{
+#ifdef _SERIAL
+	if (!cat_active) return;
+#endif
+	char Catbuffer[32];
+
+	const int filt_val[N_FILT + 1] = { 3600, 3000, 2400, 1800, 500, 200, 100, 50 };
+
+	sprintf(Catbuffer, "FW%04u;", filt_val[filt]);
+	Serial.print(Catbuffer);
 }
 #endif //CAT
 

--- a/usdx.ino
+++ b/usdx.ino
@@ -5360,6 +5360,9 @@ void analyseCATcmd()    // Supported Kenwood TS-480 protocol CAT commands
 	else if ((CATcmd[0] == 'V') && (CATcmd[1] == 'X') && (CATcmd[2] != ';'))
 		Command_VX(CATcmd[2]);
 
+	else if ((CATcmd[0] == 'F') && (CATcmd[1] == 'W') && (CATcmd[2] == ';'))
+		Command_FW();
+
 	/*
 	The following CAT extensions are available to support remote operatons. Use a baudrate of 115200 when enabling CAT_STREAMING config switch:
 
@@ -5685,6 +5688,19 @@ void Command_PS()
 
 void Command_PS1()
 {
+}
+
+void Command_FW()
+{
+#ifdef _SERIAL
+	if (!cat_active) return;
+#endif
+	char Catbuffer[32];
+
+	const int filt_val[N_FILT + 1] = { 3600, 3000, 2400, 1800, 500, 200, 100, 50 };
+
+	sprintf(Catbuffer, "FW%04u;", filt_val[filt]);
+	Serial.print(Catbuffer);
 }
 #endif //CAT
 

--- a/usdxBLACKBRICK.ino
+++ b/usdxBLACKBRICK.ino
@@ -5392,6 +5392,9 @@ void analyseCATcmd()    // Supported Kenwood TS-480 protocol CAT commands
 	else if ((CATcmd[0] == 'V') && (CATcmd[1] == 'X') && (CATcmd[2] != ';'))
 		Command_VX(CATcmd[2]);
 
+	else if ((CATcmd[0] == 'F') && (CATcmd[1] == 'W') && (CATcmd[2] == ';'))
+		Command_FW();
+
 	/*
 	The following CAT extensions are available to support remote operatons. Use a baudrate of 115200 when enabling CAT_STREAMING config switch:
 
@@ -5717,6 +5720,19 @@ void Command_PS()
 
 void Command_PS1()
 {
+}
+
+void Command_FW()
+{
+#ifdef _SERIAL
+	if (!cat_active) return;
+#endif
+	char Catbuffer[32];
+
+	const int filt_val[N_FILT + 1] = { 3600, 3000, 2400, 1800, 500, 200, 100, 50 };
+
+	sprintf(Catbuffer, "FW%04u;", filt_val[filt]);
+	Serial.print(Catbuffer);
 }
 #endif //CAT
 

--- a/usdxREDBUTTONS.ino
+++ b/usdxREDBUTTONS.ino
@@ -5386,6 +5386,9 @@ void analyseCATcmd()    // Supported Kenwood TS-480 protocol CAT commands
 	else if ((CATcmd[0] == 'V') && (CATcmd[1] == 'X') && (CATcmd[2] != ';'))
 		Command_VX(CATcmd[2]);
 
+	else if ((CATcmd[0] == 'F') && (CATcmd[1] == 'W') && (CATcmd[2] == ';'))
+		Command_FW();
+
 	/*
 	The following CAT extensions are available to support remote operatons. Use a baudrate of 115200 when enabling CAT_STREAMING config switch:
 
@@ -5711,6 +5714,19 @@ void Command_PS()
 
 void Command_PS1()
 {
+}
+
+void Command_FW()
+{
+#ifdef _SERIAL
+	if (!cat_active) return;
+#endif
+	char Catbuffer[32];
+
+	const int filt_val[N_FILT + 1] = { 3600, 3000, 2400, 1800, 500, 200, 100, 50 };
+
+	sprintf(Catbuffer, "FW%04u;", filt_val[filt]);
+	Serial.print(Catbuffer);
 }
 #endif //CAT
 

--- a/usdxREDCORNERS.ino
+++ b/usdxREDCORNERS.ino
@@ -5392,6 +5392,9 @@ void analyseCATcmd()    // Supported Kenwood TS-480 protocol CAT commands
 	else if ((CATcmd[0] == 'V') && (CATcmd[1] == 'X') && (CATcmd[2] != ';'))
 		Command_VX(CATcmd[2]);
 
+	else if ((CATcmd[0] == 'F') && (CATcmd[1] == 'W') && (CATcmd[2] == ';'))
+		Command_FW();
+
 	/*
 	The following CAT extensions are available to support remote operatons. Use a baudrate of 115200 when enabling CAT_STREAMING config switch:
 
@@ -5718,6 +5721,20 @@ void Command_PS()
 void Command_PS1()
 {
 }
+
+void Command_FW()
+{
+#ifdef _SERIAL
+	if (!cat_active) return;
+#endif
+	char Catbuffer[32];
+
+	const int filt_val[N_FILT + 1] = { 3600, 3000, 2400, 1800, 500, 200, 100, 50 };
+
+	sprintf(Catbuffer, "FW%04u;", filt_val[filt]);
+	Serial.print(Catbuffer);
+}
+
 #endif //CAT
 
 void fatal(const __FlashStringHelper * msg, int value = 0, char unit = '\0') {

--- a/usdxWHITEBUTTONS.ino
+++ b/usdxWHITEBUTTONS.ino
@@ -5392,6 +5392,9 @@ void analyseCATcmd()    // Supported Kenwood TS-480 protocol CAT commands
 	else if ((CATcmd[0] == 'V') && (CATcmd[1] == 'X') && (CATcmd[2] != ';'))
 		Command_VX(CATcmd[2]);
 
+	else if ((CATcmd[0] == 'F') && (CATcmd[1] == 'W') && (CATcmd[2] == ';'))
+		Command_FW();
+
 	/*
 	The following CAT extensions are available to support remote operatons. Use a baudrate of 115200 when enabling CAT_STREAMING config switch:
 
@@ -5717,6 +5720,19 @@ void Command_PS()
 
 void Command_PS1()
 {
+}
+
+void Command_FW()
+{
+#ifdef _SERIAL
+	if (!cat_active) return;
+#endif
+	char Catbuffer[32];
+
+	const int filt_val[N_FILT + 1] = { 3600, 3000, 2400, 1800, 500, 200, 100, 50 };
+
+	sprintf(Catbuffer, "FW%04u;", filt_val[filt]);
+	Serial.print(Catbuffer);
 }
 #endif //CAT
 


### PR DESCRIPTION
The FW CAT command allows the computer to query the filter settings of the radio, is currently being queried by WSJT-X when operating in WSPR mode and makes the radio crash after a couple of hours because two error response are returned in the same buffer. With this command implemented the radio does not crash anymore.